### PR TITLE
Add watcher.zk.exception metric to capture if ZK watcher is not applying leadership state properly; Add automated build upon PR

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,16 @@
+name: tiered-storage-build
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Maven
         run: mvn -B package --file pom.xml

--- a/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/UploaderMetrics.java
+++ b/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/UploaderMetrics.java
@@ -34,4 +34,5 @@ public class UploaderMetrics {
     public static final String ADD_WATCHER_FAILED_METRIC = UPLOADER_METRIC_PREFIX + "." + "add.watcher.failed";
     public static final String ENQUEUE_TO_UPLOAD_LATENCY_MS_METRIC = UPLOADER_METRIC_PREFIX + "." + "enqueue.to.upload.latency.ms";
     public static final String RETRY_MARKED_FOR_DELETION_COUNT_METRIC = UPLOADER_METRIC_PREFIX + "." + "retry.marked.for.deletion.count";
+    public static final String WATCHER_ZK_EXCEPTION_METRIC = UPLOADER_METRIC_PREFIX + "." + "watcher.zk.exception";
 }

--- a/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/leadership/KafkaLeadershipWatcher.java
+++ b/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/leadership/KafkaLeadershipWatcher.java
@@ -96,6 +96,13 @@ public class KafkaLeadershipWatcher {
                 applyCurrentState();
             } catch (Exception e) {
                 LOG.error("Caught exception while applying current state", e);
+                MetricRegistryManager.getInstance(config.getMetricsConfiguration()).incrementCounter(
+                        null,
+                        null,
+                        UploaderMetrics.WATCHER_ZK_EXCEPTION_METRIC,
+                        "cluster=" + environmentProvider.clusterId(),
+                        "broker=" + environmentProvider.brokerId()
+                );
             }
         }, config.getZkWatcherPollIntervalSeconds(), config.getZkWatcherPollIntervalSeconds(), java.util.concurrent.TimeUnit.SECONDS);
     }


### PR DESCRIPTION
Emit a metric when an exception is caught in the ZK processing loop. Also adding automated build upon PR.