### PR TITLE
Fix bug where exception is mishandled due to misclassification

### DIFF
--- a/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/Utils.java
+++ b/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/Utils.java
@@ -85,7 +85,7 @@ public class Utils {
         if (throwable == null) {
             return false;
         }
-        if (throwable.getClass().isAssignableFrom(toMatch)) {
+        if (toMatch.isAssignableFrom(throwable.getClass())) {
             return true;
         }
         return isAssignableFromRecursive(throwable.getCause(), toMatch);

--- a/ts-segment-uploader/src/test/java/com/pinterest/kafka/tieredstorage/uploader/TestUtils.java
+++ b/ts-segment-uploader/src/test/java/com/pinterest/kafka/tieredstorage/uploader/TestUtils.java
@@ -1,0 +1,31 @@
+package com.pinterest.kafka.tieredstorage.uploader;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.NoSuchFileException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestUtils {
+
+    @Test
+    public void testIsAssignableFromRecursive() {
+        boolean result = Utils.isAssignableFromRecursive(new Throwable(), NoSuchFileException.class);
+        assertFalse(result);
+
+        result = Utils.isAssignableFromRecursive(new Throwable(new CompletionException(new TimeoutException("test"))), NoSuchFileException.class);
+        assertFalse(result);
+
+        result = Utils.isAssignableFromRecursive(new Throwable(new CompletionException(new NoSuchFileException("test"))), NoSuchFileException.class);
+        assertTrue(result);
+
+        result = Utils.isAssignableFromRecursive(new Exception(), Throwable.class);
+        assertTrue(result);
+
+        result = Utils.isAssignableFromRecursive(new Throwable(), Exception.class);
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
If the provided `throwable` simply has a `Throwable` or `Exception` object (the generic ones) within it, the previous logic in `Utils.isAssignableFromRecursive(Throwable throwable, Class<?> toMatch)` would have matched it to any exception provided in the argument `toMatch` since `Throwable.class`/`Exception.class` is a superclass of any other exception / throwable. This results in `Utils.isAssignableFromRecursive(new Throwable(), NoSuchFileException.class)` return true, when it should return false. The misclassification of an exception can result in mishandling of failed uploads.

By swapping the order of the two arguments such that we call `toMatch.isAssignableFrom(throwable.getClass())`, we ensure that the method only returns true if `toMatch` is actually an instance of, or a parent-class instance of the provided `throwable`.

Simple example:
- Incorrect behavior: `Utils.isAssignableFromRecursive(new Throwable(), NoSuchFileException.class)` --> `true`
- Expected behavior: `Utils.isAssignableFromRecursive(new Throwable(), NoSuchFileException.class)` --> `false`