### PR TITLE
Fix missing DTW thread due to invalid WatchKeys

### DIFF
--- a/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/DirectoryTreeWatcher.java
+++ b/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/DirectoryTreeWatcher.java
@@ -405,16 +405,14 @@ public class DirectoryTreeWatcher implements Runnable {
             while (!cancelled) {
                 try {
                     WatchKey key = watchService.take();
-                    LOG.info("Received watch key: " + key);
                     for (WatchEvent<?> event : key.pollEvents()) {
                         WatchEvent.Kind<?> kind = event.kind();
                         Path subpath = (Path) event.context();
                         Path path = ((Path) key.watchable()).resolve(subpath);
                         processEvent(path, kind, key);
                     }
-                    LOG.info("Successfully processed all events. Resetting watch key: " + key);
                     if (!key.reset()) {
-                        LOG.error("WatchKey is invalid and could not be reset. Should exit program here.");
+                        LOG.warn("Cancelling WatchKey because it is no longer valid.");
                         MetricRegistryManager.getInstance(config.getMetricsConfiguration()).incrementCounter(
                                 null,
                                 null,
@@ -422,7 +420,7 @@ public class DirectoryTreeWatcher implements Runnable {
                                 "cluster=" + environmentProvider.clusterId(),
                                 "broker=" + environmentProvider.brokerId()
                         );
-                        break;
+                        key.cancel();
                     }
                 } catch (InterruptedException e) {
                     LOG.warn("Program execution was interrupted.");

--- a/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/DirectoryTreeWatcher.java
+++ b/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/DirectoryTreeWatcher.java
@@ -412,7 +412,7 @@ public class DirectoryTreeWatcher implements Runnable {
                         processEvent(path, kind, key);
                     }
                     if (!key.reset()) {
-                        LOG.warn("Cancelling WatchKey because it is no longer valid.");
+                        LOG.warn("Cancelling WatchKey for " + key.watchable() + " because it is no longer valid.");
                         MetricRegistryManager.getInstance(config.getMetricsConfiguration()).incrementCounter(
                                 null,
                                 null,

--- a/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/UploaderMetrics.java
+++ b/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/UploaderMetrics.java
@@ -24,6 +24,7 @@ public class UploaderMetrics {
     public static final String WATCHER_ADDED_METRIC = UPLOADER_METRIC_PREFIX + "." + "watcher.added";
     public static final String WATCHER_REMOVED_METRIC = UPLOADER_METRIC_PREFIX + "." + "watcher.removed";
     public static final String WATCHER_COUNT_METRIC = UPLOADER_METRIC_PREFIX + "." + "watcher.count";
+    public static final String WATCHER_KEY_RESET_METRIC = UPLOADER_METRIC_PREFIX + "." + "watcher.key.reset";
     public static final String HEARTBEAT_METRIC = UPLOADER_METRIC_PREFIX + "." + "heartbeat";
     public static final String KAFKA_LEADER_SET_METRIC = UPLOADER_METRIC_PREFIX + "." + "kafka.leader.set";
     public static final String KAFKA_LEADER_UNSET_METRIC = UPLOADER_METRIC_PREFIX + "." + "kafka.leader.unset";


### PR DESCRIPTION
There is a race condition that can surface where a WatchKey for a partition directory is cancelled before its reset. When this happens, we would break out of the DirectoryTreeWatcher thread loop that processes file system events, resulting in an idle uploader state.

To resolve this, we avoid breaking out the loop and cancel the key in case the key is invalid for a different reason. If the key is already cancel, this should be a no-op. We also add a metric and a log to track this.