### PR TITLE
Upgrade ts-consumer to kafka-client 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.kafka.tieredstorage</groupId>
     <artifactId>kafka-tiered-storage</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>kafka-tiered-storage</name>
     <description>Kafka Tiered Storage</description>

--- a/ts-common/pom.xml
+++ b/ts-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pinterest.kafka.tieredstorage</groupId>
         <artifactId>kafka-tiered-storage</artifactId>
-        <version>0.0.2</version>
+        <version>0.0.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ts-consumer/pom.xml
+++ b/ts-consumer/pom.xml
@@ -31,12 +31,12 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.3.1</version>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>
-            <version>2.3.1</version>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/ts-consumer/pom.xml
+++ b/ts-consumer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kafka-tiered-storage</artifactId>
         <groupId>com.pinterest.kafka.tieredstorage</groupId>
-        <version>0.0.2</version>
+        <version>0.0.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ts-consumer/pom.xml
+++ b/ts-consumer/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>3.1.5</version>
+            <version>2.3.4</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/ts-consumer/src/main/java/com/pinterest/kafka/tieredstorage/consumer/S3PartitionConsumer.java
+++ b/ts-consumer/src/main/java/com/pinterest/kafka/tieredstorage/consumer/S3PartitionConsumer.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.TreeMap;
 
@@ -279,12 +280,12 @@ public class S3PartitionConsumer<K, V> {
                         record.offset(),
                         record.timestamp(),
                         TimestampType.CREATE_TIME,
-                        record.checksumOrNull() == null ? -1 : record.checksumOrNull(),
                         record.keySize(),
                         record.valueSize(),
                         record.key() == null ? null : keyDeserializer.deserialize(topicPartition.topic(), Utils.toArray(record.key())),
                         record.value() == null ? null : valueDeserializer.deserialize(topicPartition.topic(), Utils.toArray(record.value())),
-                        headers
+                        headers,
+                    Optional.empty()
                 ));
                 ++recordCount;
                 fetchSizeBytes += record.sizeInBytes();

--- a/ts-consumer/src/main/java/com/pinterest/kafka/tieredstorage/consumer/TieredStorageConsumer.java
+++ b/ts-consumer/src/main/java/com/pinterest/kafka/tieredstorage/consumer/TieredStorageConsumer.java
@@ -195,10 +195,13 @@ public class TieredStorageConsumer<K, V> implements Consumer<K, V> {
         subscription.clear();
         subscription.addAll(topics);
         kafkaConsumer.unsubscribe();
-        rebalanceListener.setCustomRebalanceListener(callback);
-        kafkaConsumer.subscribe(topics, rebalanceListener);
         if (tieredStorageConsumptionPossible()) {
+            rebalanceListener.setCustomRebalanceListener(callback);
+            kafkaConsumer.subscribe(topics, rebalanceListener);
             setTieredStorageLocations(topics);
+        }
+        else {
+            kafkaConsumer.subscribe(topics, callback);
         }
     }
 
@@ -207,10 +210,12 @@ public class TieredStorageConsumer<K, V> implements Consumer<K, V> {
         assignments.clear();
         subscription.clear();
         kafkaConsumer.unsubscribe();
-        rebalanceListener.setCustomRebalanceListener(callback);
-        kafkaConsumer.subscribe(pattern, rebalanceListener);
         if (tieredStorageConsumptionPossible()) {
+            rebalanceListener.setCustomRebalanceListener(callback);
+            kafkaConsumer.subscribe(pattern, rebalanceListener);
             setTieredStorageLocations(kafkaConsumer.subscription());
+        } else {
+            kafkaConsumer.subscribe(pattern, callback);
         }
         subscription.addAll(kafkaConsumer.subscription());
     }

--- a/ts-consumer/src/main/java/com/pinterest/kafka/tieredstorage/consumer/TieredStorageConsumer.java
+++ b/ts-consumer/src/main/java/com/pinterest/kafka/tieredstorage/consumer/TieredStorageConsumer.java
@@ -199,9 +199,8 @@ public class TieredStorageConsumer<K, V> implements Consumer<K, V> {
             rebalanceListener.setCustomRebalanceListener(callback);
             kafkaConsumer.subscribe(topics, rebalanceListener);
             setTieredStorageLocations(topics);
-        }
-        else {
-            kafkaConsumer.subscribe(topics, callback);
+        } else {
+            kafkaConsumer.subscribe(topics);
         }
     }
 
@@ -584,7 +583,7 @@ public class TieredStorageConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public Map<MetricName, ? extends Metric> metrics() {
-        return null;
+        return kafkaConsumer.metrics();
     }
 
     /**

--- a/ts-consumer/src/main/java/org/apache/kafka/common/record/DefaultS3ChannelRecordBatch.java
+++ b/ts-consumer/src/main/java/org/apache/kafka/common/record/DefaultS3ChannelRecordBatch.java
@@ -1,6 +1,7 @@
 package org.apache.kafka.common.record;
 
 import java.nio.ByteBuffer;
+import java.util.OptionalLong;
 
 class DefaultS3ChannelRecordBatch extends S3ChannelRecordBatch {
 
@@ -55,6 +56,11 @@ class DefaultS3ChannelRecordBatch extends S3ChannelRecordBatch {
     @Override
     public boolean isTransactional() {
         return loadBatchHeader().isTransactional();
+    }
+
+    @Override
+    public OptionalLong deleteHorizonMs() {
+        return loadBatchHeader().deleteHorizonMs();
     }
 
     @Override

--- a/ts-consumer/src/main/java/org/apache/kafka/common/record/S3ChannelRecordBatch.java
+++ b/ts-consumer/src/main/java/org/apache/kafka/common/record/S3ChannelRecordBatch.java
@@ -1,6 +1,7 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.CloseableIterator;
 
 import java.io.IOException;
@@ -72,7 +73,6 @@ public abstract class S3ChannelRecordBatch extends AbstractRecordBatch {
         return loadFullBatch().iterator();
     }
 
-    @Override
     public CloseableIterator<Record> streamingIterator(BufferSupplier bufferSupplier) {
         return loadFullBatch().streamingIterator(bufferSupplier);
     }

--- a/ts-consumer/src/main/java/org/apache/kafka/common/record/S3Records.java
+++ b/ts-consumer/src/main/java/org/apache/kafka/common/record/S3Records.java
@@ -2,6 +2,7 @@ package org.apache.kafka.common.record;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.network.TransferableChannel;
 import org.apache.kafka.common.utils.AbstractIterator;
 import org.apache.kafka.common.utils.Time;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -115,8 +116,7 @@ public class S3Records extends AbstractRecords {
     }
 
     @Override
-    public long writeTo(GatheringByteChannel channel, long position, int length) {
-
+    public long writeTo(TransferableChannel channel, long position, int length) {
         throw new NotImplementedException("S3Records objects are meant to be used only for reading records from S3");
     }
 

--- a/ts-examples/pom.xml
+++ b/ts-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
           <groupId>com.pinterest.kafka.tieredstorage</groupId>
           <artifactId>kafka-tiered-storage</artifactId>
-          <version>0.0.2</version>
+          <version>0.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>ts-examples</artifactId>

--- a/ts-examples/pom.xml
+++ b/ts-examples/pom.xml
@@ -80,8 +80,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>9</source>
-                    <target>9</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/ts-segment-uploader/pom.xml
+++ b/ts-segment-uploader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kafka-tiered-storage</artifactId>
         <groupId>com.pinterest.kafka.tieredstorage</groupId>
-        <version>0.0.2</version>
+        <version>0.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ts-segment-uploader/pom.xml
+++ b/ts-segment-uploader/pom.xml
@@ -174,8 +174,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>9</source>
-                    <target>9</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Upgrading ts-consumer `org.apache.kafka:kafka-client` from `2.3.1 -> 3.4.0`. Mainly adding missing APIs to TieredStorageConsumer and fixing references to other APIs that changed in the new version.

Also fixing `TieredStorageConsumer.metrics()` returning null which causes NPEs for applications that rely on this method.