### PR TITLE
Fix NPE in consumer metrics call

### DIFF
--- a/ts-consumer/src/main/java/com/pinterest/kafka/tieredstorage/consumer/TieredStorageConsumer.java
+++ b/ts-consumer/src/main/java/com/pinterest/kafka/tieredstorage/consumer/TieredStorageConsumer.java
@@ -558,7 +558,7 @@ public class TieredStorageConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public Map<MetricName, ? extends Metric> metrics() {
-        return null;
+        return kafkaConsumer.metrics();
     }
 
     /**


### PR DESCRIPTION
`TieredStorageConsumer.metrics()` returns null which causes NPEs for applications that rely on this method.