### PR TITLE
Upgrade ts-consumer kafka client to 3.4.0

### DIFF
--- a/ts-consumer/pom.xml
+++ b/ts-consumer/pom.xml
@@ -31,12 +31,12 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.3.1</version>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>
-            <version>2.3.1</version>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/ts-consumer/src/main/java/com/pinterest/kafka/tieredstorage/consumer/S3PartitionConsumer.java
+++ b/ts-consumer/src/main/java/com/pinterest/kafka/tieredstorage/consumer/S3PartitionConsumer.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.TreeMap;
 
@@ -272,19 +273,21 @@ public class S3PartitionConsumer<K, V> {
                 // TODO: Confirm if the below line is needed.
                 Arrays.stream(record.headers()).forEach(headers::add);
 
-
                 records.add(new ConsumerRecord<>(
-                        topicPartition.topic(),
-                        topicPartition.partition(),
-                        record.offset(),
-                        record.timestamp(),
-                        TimestampType.CREATE_TIME,
-                        record.checksumOrNull() == null ? -1 : record.checksumOrNull(),
-                        record.keySize(),
-                        record.valueSize(),
-                        record.key() == null ? null : keyDeserializer.deserialize(topicPartition.topic(), Utils.toArray(record.key())),
-                        record.value() == null ? null : valueDeserializer.deserialize(topicPartition.topic(), Utils.toArray(record.value())),
-                        headers
+                    topicPartition.topic(),
+                    topicPartition.partition(),
+                    record.offset(),
+                    record.timestamp(),
+                    TimestampType.CREATE_TIME,
+                    record.keySize(),
+                    record.valueSize(),
+                    record.key() == null ? null
+                                         : keyDeserializer.deserialize(topicPartition.topic(),
+                                             Utils.toArray(record.key())),
+                    record.value() == null ? null
+                                           : valueDeserializer.deserialize(topicPartition.topic(),
+                                               Utils.toArray(record.value())),
+                    headers, Optional.empty()
                 ));
                 ++recordCount;
                 fetchSizeBytes += record.sizeInBytes();

--- a/ts-consumer/src/main/java/org/apache/kafka/common/record/DefaultS3ChannelRecordBatch.java
+++ b/ts-consumer/src/main/java/org/apache/kafka/common/record/DefaultS3ChannelRecordBatch.java
@@ -1,6 +1,7 @@
 package org.apache.kafka.common.record;
 
 import java.nio.ByteBuffer;
+import java.util.OptionalLong;
 
 class DefaultS3ChannelRecordBatch extends S3ChannelRecordBatch {
 
@@ -55,6 +56,11 @@ class DefaultS3ChannelRecordBatch extends S3ChannelRecordBatch {
     @Override
     public boolean isTransactional() {
         return loadBatchHeader().isTransactional();
+    }
+
+    @Override
+    public OptionalLong deleteHorizonMs() {
+        return loadBatchHeader().deleteHorizonMs();
     }
 
     @Override

--- a/ts-consumer/src/main/java/org/apache/kafka/common/record/S3ChannelRecordBatch.java
+++ b/ts-consumer/src/main/java/org/apache/kafka/common/record/S3ChannelRecordBatch.java
@@ -1,6 +1,7 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.CloseableIterator;
 
 import java.io.IOException;

--- a/ts-consumer/src/main/java/org/apache/kafka/common/record/S3Records.java
+++ b/ts-consumer/src/main/java/org/apache/kafka/common/record/S3Records.java
@@ -2,6 +2,7 @@ package org.apache.kafka.common.record;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.network.TransferableChannel;
 import org.apache.kafka.common.utils.AbstractIterator;
 import org.apache.kafka.common.utils.Time;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -115,8 +116,7 @@ public class S3Records extends AbstractRecords {
     }
 
     @Override
-    public long writeTo(GatheringByteChannel channel, long position, int length) {
-
+    public long writeTo(TransferableChannel channel, long position, int length) {
         throw new NotImplementedException("S3Records objects are meant to be used only for reading records from S3");
     }
 


### PR DESCRIPTION
Upgrading ts-consumer `org.apache.kafka:kafka-client` from `2.3.1 -> 3.4.0`. Mainly adding missing APIs to `TieredStorageConsumer` and fixing references to other APIs that changed in the new version.