### PR TITLE
Fix dangling object issue in beginning s3 offsets; bump version to 1.0.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.kafka.tieredstorage</groupId>
     <artifactId>kafka-tiered-storage</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>kafka-tiered-storage</name>
     <description>Kafka Tiered Storage</description>

--- a/ts-common/pom.xml
+++ b/ts-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pinterest.kafka.tieredstorage</groupId>
         <artifactId>kafka-tiered-storage</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ts-consumer/pom.xml
+++ b/ts-consumer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kafka-tiered-storage</artifactId>
         <groupId>com.pinterest.kafka.tieredstorage</groupId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ts-consumer/src/main/java/com/pinterest/kafka/tieredstorage/consumer/S3Utils.java
+++ b/ts-consumer/src/main/java/com/pinterest/kafka/tieredstorage/consumer/S3Utils.java
@@ -170,6 +170,10 @@ public class S3Utils {
         Map<Long, Integer> offsetToCountMap = new HashMap<>();
         for (S3Object s3Object : result.contents()) {
             String key = s3Object.key();
+            if (!key.endsWith(".log") && !key.endsWith(".index") && !key.endsWith(".timeindex")) {
+                LOG.debug(String.format("Skipping S3 object %s for topicPartition=%s in %s", key, topicPartition, s3Path));
+                continue;
+            }
             String filename = S3Utils.getFileNameFromKey(key);
             Long offset = Long.parseLong(filename.substring(0, filename.indexOf(".")));
             offsetToCountMap.put(offset, offsetToCountMap.getOrDefault(offset, 0) + 1);

--- a/ts-consumer/src/test/java/com/pinterest/kafka/tieredstorage/consumer/TestS3Base.java
+++ b/ts-consumer/src/test/java/com/pinterest/kafka/tieredstorage/consumer/TestS3Base.java
@@ -124,6 +124,20 @@ public class TestS3Base extends TestBase {
         }
     }
 
+    protected void putEmptyObjectsDanglingEarliest(String cluster, String topic, int partition, long minOffset, long maxOffset, long numOffsetsPerFile) {
+        for (long i = minOffset; i <= maxOffset; i += numOffsetsPerFile) {
+            LOG.info(String.format("Put empty object to bucket=%s, key=%s", S3_BUCKET, getS3ObjectKey(cluster, topic, partition, i, TestS3Utils.FileType.LOG)));
+            s3Client.putObject(PutObjectRequest.builder().bucket(S3_BUCKET).key(getS3ObjectKey(cluster, topic, partition, i, TestS3Utils.FileType.LOG)).build(), RequestBody.empty());
+            if (i == minOffset) {
+                continue;
+            }
+            LOG.info(String.format("Put empty object to bucket=%s, key=%s", S3_BUCKET, getS3ObjectKey(cluster, topic, partition, i, TestS3Utils.FileType.INDEX)));
+            s3Client.putObject(PutObjectRequest.builder().bucket(S3_BUCKET).key(getS3ObjectKey(cluster, topic, partition, i, TestS3Utils.FileType.INDEX)).build(), RequestBody.empty());
+            LOG.info(String.format("Put empty object to bucket=%s, key=%s", S3_BUCKET, getS3ObjectKey(cluster, topic, partition, i, TestS3Utils.FileType.TIMEINDEX)));
+            s3Client.putObject(PutObjectRequest.builder().bucket(S3_BUCKET).key(getS3ObjectKey(cluster, topic, partition, i, TestS3Utils.FileType.TIMEINDEX)).build(), RequestBody.empty());
+        }
+    }
+
     protected void putEmptyObjects(String cluster, String topic, int partition, long minOffset, long maxOffset, long numOffsetsPerFile, int prefixEntropyNumDigits) {
         for (long i = minOffset; i <= maxOffset; i += numOffsetsPerFile) {
             s3Client.putObject(PutObjectRequest.builder().bucket(S3_BUCKET).key(getS3ObjectKey(cluster, topic, partition, i, TestS3Utils.FileType.INDEX, prefixEntropyNumDigits)).build(), RequestBody.empty());

--- a/ts-consumer/src/test/java/com/pinterest/kafka/tieredstorage/consumer/TestS3PartitionConsumer.java
+++ b/ts-consumer/src/test/java/com/pinterest/kafka/tieredstorage/consumer/TestS3PartitionConsumer.java
@@ -51,6 +51,17 @@ public class TestS3PartitionConsumer extends TestS3Base {
         assertEquals(50L, s3PartitionConsumer2.beginningOffset());
     }
 
+    @Test
+    void testBeginningOffsetDangling() {
+        putEmptyObjectsDanglingEarliest(KAFKA_CLUSTER_ID, KAFKA_TOPIC, 4, 100L, 1000L, 100L);
+        Properties properties = getConsumerProperties();
+        S3Utils.overrideS3Client(s3Client);
+        String metricsReporterClassName = NoOpMetricsReporter.class.getName();
+        MetricsConfiguration metricsConfiguration = new MetricsConfiguration(metricsReporterClassName, null, null);
+        S3PartitionConsumer<byte[], byte[]> s3PartitionConsumer = new S3PartitionConsumer<>(getS3BasePrefixWithCluster(), new TopicPartition(KAFKA_TOPIC, 4), CONSUMER_GROUP, properties, metricsConfiguration);
+        assertEquals(200L, s3PartitionConsumer.beginningOffset());  // should skip 100
+    }
+
     /**
      * Test that the correct end offset is retrieved. The end offset is the offset of the last log segment present in S3
      */

--- a/ts-consumer/src/test/java/com/pinterest/kafka/tieredstorage/consumer/TestS3Utils.java
+++ b/ts-consumer/src/test/java/com/pinterest/kafka/tieredstorage/consumer/TestS3Utils.java
@@ -51,4 +51,22 @@ public class TestS3Utils extends TestS3Base {
         assertEquals(new HashSet<>(Collections.singletonList(20L)), map0.keySet());
         assertEquals(new HashSet<>(Arrays.asList(30L, 40L)), map1.keySet());
     }
+
+    @Test
+    void testGetSortedOffsetKeyMapWithDanglingObjectsEarliest() {
+        putEmptyObjectsDanglingEarliest(KAFKA_CLUSTER_ID, KAFKA_TOPIC, 0, 0L, 20L, 10L);
+
+        S3Utils.overrideS3Client(s3Client);
+        String metricsReporterClassName = NoOpMetricsReporter.class.getName();
+        MetricsConfiguration metricsConfiguration = new MetricsConfiguration(metricsReporterClassName, null, null);
+
+        TreeMap<Long, Triple<String, String, Long>> map0 = S3Utils.getSortedOffsetKeyMap(getS3BasePrefixWithCluster(), new TopicPartition(KAFKA_TOPIC, 0), S3Utils.getZeroPaddedOffset(0L), null, metricsConfiguration);
+        assertEquals(new HashSet<>(Arrays.asList(10L, 20L)), map0.keySet());
+
+        map0 = S3Utils.getSortedOffsetKeyMap(getS3BasePrefixWithCluster(), new TopicPartition(KAFKA_TOPIC, 0), S3Utils.getZeroPaddedOffset(5L), null, metricsConfiguration);
+        assertEquals(new HashSet<>(Arrays.asList(10L, 20L)), map0.keySet());
+
+        map0 = S3Utils.getSortedOffsetKeyMap(getS3BasePrefixWithCluster(), new TopicPartition(KAFKA_TOPIC, 0), S3Utils.getZeroPaddedOffset(33L), null, metricsConfiguration);
+        assertEquals(new HashSet<>(Collections.singletonList(20L)), map0.keySet());
+    }
 }

--- a/ts-examples/pom.xml
+++ b/ts-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
           <groupId>com.pinterest.kafka.tieredstorage</groupId>
           <artifactId>kafka-tiered-storage</artifactId>
-          <version>1.0.1</version>
+          <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <name>com.pinterest.kafka.tieredstorage:ts-examples</name>

--- a/ts-segment-uploader/pom.xml
+++ b/ts-segment-uploader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kafka-tiered-storage</artifactId>
         <groupId>com.pinterest.kafka.tieredstorage</groupId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Fix dangling object issue in S3 due to GC cleaning up some, but not all, of the `.index`, `.log`, and `.timeindex` files. The fix is to only return offsets in `getSortedOffsetKeyMap()` where all 3 are present.