### PR TITLE
Make MetricRegistryManager singleton again to fix thread / memory leak; bump version to 1.0.3-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.kafka.tieredstorage</groupId>
     <artifactId>kafka-tiered-storage</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>kafka-tiered-storage</name>
     <description>Kafka Tiered Storage</description>

--- a/ts-common/pom.xml
+++ b/ts-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pinterest.kafka.tieredstorage</groupId>
         <artifactId>kafka-tiered-storage</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ts-common/src/test/java/com/pinterest/kafka/tieredstorage/common/metrics/TestMetrics.java
+++ b/ts-common/src/test/java/com/pinterest/kafka/tieredstorage/common/metrics/TestMetrics.java
@@ -23,13 +23,13 @@ public class TestMetrics {
         executorService.schedule(() -> {
             try {
                 MetricRegistryManager.getInstance(config).incrementCounter("test", 0, "test", "tag111=value");
-                assertEquals(2, MetricRegistryManager.getRefCount());   // new thread has incremented ref count
+                assertEquals(1, MetricRegistryManager.getRefCount());   // new thread has incremented ref count
                 MetricRegistryManager.getInstance(config).shutdown();
                 assertEquals(1, MetricRegistryManager.getRefCount());
                 MetricRegistryManager.getInstance(config).incrementCounter("test", 0, "test", "tag222=value");
-                assertEquals(2, MetricRegistryManager.getRefCount());   // new thread has incremented ref count
+                assertEquals(1, MetricRegistryManager.getRefCount());   // new thread has incremented ref count
                 MetricRegistryManager.getInstance(config).incrementCounter("test", 0, "test", "tag333=value");
-                assertEquals(2, MetricRegistryManager.getRefCount());   // new thread has incremented ref count
+                assertEquals(1, MetricRegistryManager.getRefCount());   // new thread has incremented ref count
                 MetricRegistryManager.getInstance(config).shutdown();
                 assertEquals(1, MetricRegistryManager.getRefCount());
                 isNewThreadShutdown.set(true);
@@ -47,7 +47,12 @@ public class TestMetrics {
         }
         assertEquals(1, MetricRegistryManager.getRefCount());
         MetricRegistryManager.getInstance(config).incrementCounter("test", 0, "test", "tag9=value");
+
+        // call shutdown
         MetricRegistryManager.getInstance(config).shutdown();
-        assertEquals(0, MetricRegistryManager.getRefCount());
+
+        // ensure that the rest of the ops can still run
+        MetricRegistryManager.getInstance(config).incrementCounter("test", 0, "test", "tag10=value");
+        MetricRegistryManager.getInstance(config).incrementCounter("test", 0, "test", "tag11=value");
     }
 }

--- a/ts-consumer/pom.xml
+++ b/ts-consumer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kafka-tiered-storage</artifactId>
         <groupId>com.pinterest.kafka.tieredstorage</groupId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ts-examples/pom.xml
+++ b/ts-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
           <groupId>com.pinterest.kafka.tieredstorage</groupId>
           <artifactId>kafka-tiered-storage</artifactId>
-          <version>1.0.2</version>
+          <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <name>com.pinterest.kafka.tieredstorage:ts-examples</name>

--- a/ts-segment-uploader/pom.xml
+++ b/ts-segment-uploader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kafka-tiered-storage</artifactId>
         <groupId>com.pinterest.kafka.tieredstorage</groupId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
ThreadLocal metricRegistryManager can cause thread / memory leak in uploader when there are unbounded number of threads created upon s3 upload callbacks. Change implementation back to singleton static instance, but skip shutdown() so that consumers in the same JVM will not interfere with each other even if one of them calls close()/shutdown()