### PR TITLE
Avoid retrying offset.wm failed uploads

### DIFF
--- a/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/DirectoryTreeWatcher.java
+++ b/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/DirectoryTreeWatcher.java
@@ -292,6 +292,23 @@ public class DirectoryTreeWatcher implements Runnable {
     }
 
     private void handleUploadException(UploadTask uploadTask, Throwable throwable, TopicPartition topicPartition) {
+        // Don't retry offset.wm files if upload fails and don't send to DLQ
+        if (uploadTask.getFullFilename().endsWith(".wm")) {
+            LOG.warn(String.format("Watermark file upload failed: %s --> %s. Skipping retries and DLQ as configured. Error: %s", 
+                    uploadTask.getAbsolutePath(), uploadTask.getUploadDestinationPathString(), throwable.getMessage()));
+            // Send a specific metric for watermark file failures
+            MetricRegistryManager.getInstance(config.getMetricsConfiguration()).incrementCounter(
+                    topicPartition.topic(),
+                    topicPartition.partition(),
+                    UploaderMetrics.WATERMARK_FILE_UPLOAD_ERROR_METRIC,
+                    "exception=" + throwable.getClass().getName(),
+                    "cluster=" + environmentProvider.clusterId(),
+                    "broker=" + environmentProvider.brokerId(),
+                    "offset=" + uploadTask.getOffset()
+            );
+            return;
+        }
+
         if (Utils.isAssignableFromRecursive(throwable, NoSuchFileException.class)) {
             if (uploadTask.getTries() <= config.getUploadMaxRetries()) {
                 // retry with .deleted suffix

--- a/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/UploaderMetrics.java
+++ b/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/UploaderMetrics.java
@@ -35,4 +35,5 @@ public class UploaderMetrics {
     public static final String ENQUEUE_TO_UPLOAD_LATENCY_MS_METRIC = UPLOADER_METRIC_PREFIX + "." + "enqueue.to.upload.latency.ms";
     public static final String RETRY_MARKED_FOR_DELETION_COUNT_METRIC = UPLOADER_METRIC_PREFIX + "." + "retry.marked.for.deletion.count";
     public static final String WATCHER_LEADERSHIP_EXCEPTION_METRIC = UPLOADER_METRIC_PREFIX + "." + "watcher.leadership.exception";
+    public static final String WATERMARK_FILE_UPLOAD_ERROR_METRIC = UPLOADER_METRIC_PREFIX + "." + "watermark.file.upload.error";
 }


### PR DESCRIPTION
Most of this was generated by Cursor IDE. 

Avoid retrying offset.wm failed uploads to prevent retries from overwriting more recent watermark uploads. We will also skip sending failed offset.wm uploads to the DeadLetterQueue since they do not need any such handling.

Disabling retries is safe because the next successful watermark upload will update the committed offset.