### PR TITLE
Minor metrics fix; bump version to 1.0.5-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.kafka.tieredstorage</groupId>
     <artifactId>kafka-tiered-storage</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>kafka-tiered-storage</name>
     <description>Kafka Tiered Storage</description>

--- a/ts-common/pom.xml
+++ b/ts-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pinterest.kafka.tieredstorage</groupId>
         <artifactId>kafka-tiered-storage</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ts-consumer/pom.xml
+++ b/ts-consumer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kafka-tiered-storage</artifactId>
         <groupId>com.pinterest.kafka.tieredstorage</groupId>
-        <version>1.0.4</version>
+        <version>1.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ts-examples/pom.xml
+++ b/ts-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
           <groupId>com.pinterest.kafka.tieredstorage</groupId>
           <artifactId>kafka-tiered-storage</artifactId>
-          <version>1.0.4</version>
+          <version>1.0.5-SNAPSHOT</version>
     </parent>
 
     <name>com.pinterest.kafka.tieredstorage:ts-examples</name>

--- a/ts-segment-uploader/pom.xml
+++ b/ts-segment-uploader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kafka-tiered-storage</artifactId>
         <groupId>com.pinterest.kafka.tieredstorage</groupId>
-        <version>1.0.4</version>
+        <version>1.0.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/management/SegmentManager.java
+++ b/ts-segment-uploader/src/main/java/com/pinterest/kafka/tieredstorage/uploader/management/SegmentManager.java
@@ -281,6 +281,14 @@ public abstract class SegmentManager {
                 if (cutoffEntry == null) {
                     // nothing is expired according to metadata timeindex
                     LOG.info(String.format("No segments are expired for topicPartition=%s", leadingPartition));
+                    MetricRegistryManager.getInstance(config.getMetricsConfiguration()).updateCounter(
+                            leadingPartition.topic(),
+                            leadingPartition.partition(),
+                            UploaderMetrics.SEGMENT_MANAGER_LOG_START_OFFSET_METRIC,
+                            timeIndex.getFirstEntry() == null ? -1L : timeIndex.getFirstEntry().getBaseOffset(),
+                            "cluster=" + environmentProvider.clusterId(),
+                            "broker=" + environmentProvider.brokerId()
+                    );
                     continue;
                 }
                 cutoffOffset = cutoffEntry.getBaseOffset();    // everything including and before this offset should be removed


### PR DESCRIPTION
Emit LOG_START_OFFSET metric on S3 even when no cleanup is performed to keep the metric up-to-date at all times.

Bump version to 1.0.5-SNAPSHOT